### PR TITLE
Support pip v8.x

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -47,7 +47,7 @@ class beaver::package (
       ensure       => $version,
       pkgname      => $package_name,
       virtualenv   => $venv,
-      install_args => "--download-cache ${venv}/.pip-cache",
+      install_args => "--cache-dir ${venv}/.pip-cache",
       owner        => 'root',
       require      => User[$user],
       notify       => Class['beaver::service'],


### PR DESCRIPTION
This pull request removes the `--download-cache` install argument for pip.  It's replaced with `--cache-dir` which is the correct argument for the latest version of pip (8.0.0 release on 2016-01-19). See the release notes linked [here](https://pip.pypa.io/en/stable/news/#release-notes).

```
BACKWARD INCOMPATIBLE Remove the --download-cache which had been deprecated and no-op'd in 6.0.
```
